### PR TITLE
[fix] Don't create new run at import

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+This repository is folked from [mlflow/mlflow-export-import](https://github.com/mlflow/mlflow-export-import).
+You need to restore backend DB before using this script.
+
 # MLflow Export Import
 
 This package provides tools to copy MLflow objects (runs, experiments or registered models) from one MLflow tracking server (Databricks workspace) to another.

--- a/mlflow_export_import/common/mlflow_utils.py
+++ b/mlflow_export_import/common/mlflow_utils.py
@@ -45,7 +45,7 @@ def get_experiment(mlflow_client, exp_id_or_name):
     return exp
 
 
-def set_experiment(mlflow_client, dbx_client, exp_name):
+def set_experiment(mlflow_client, dbx_client, exp_name, is_create_new_exp=False):
     """
     Set experiment name. 
     For Databricks, create the workspace directory if it doesn't exist.
@@ -54,9 +54,9 @@ def set_experiment(mlflow_client, dbx_client, exp_name):
     from mlflow_export_import import utils
     if utils.importing_into_databricks():
         create_workspace_dir(dbx_client, os.path.dirname(exp_name))
-    try:
+    if is_create_new_exp:
         return mlflow_client.create_experiment(exp_name)
-    except Exception:
+    else:
         exp = mlflow_client.get_experiment_by_name(exp_name)
         return exp.experiment_id
 

--- a/mlflow_export_import/run/import_run.py
+++ b/mlflow_export_import/run/import_run.py
@@ -64,9 +64,9 @@ class RunImporter():
         src_run_path = os.path.join(input_dir,"run.json")
         src_run_dct = utils.read_json_file(src_run_path)
 
-        run = self.mlflow_client.create_run(exp.experiment_id)
-        run_id = run.info.run_id
+        run_id = src_run_dct["info"].get("run_id", None)
         try:
+            run = self.mlflow_client.get_run(run_id)
             self._import_run_data(src_run_dct, run_id, src_run_dct["info"]["user_id"])
             path = os.path.join(input_dir, "artifacts")
             if os.path.exists(_filesystem.mk_local_path(path)):

--- a/mlflow_export_import/run/import_run.py
+++ b/mlflow_export_import/run/import_run.py
@@ -67,7 +67,6 @@ class RunImporter():
         run_id = src_run_dct["info"].get("run_id", None)
         try:
             run = self.mlflow_client.get_run(run_id)
-            self._import_run_data(src_run_dct, run_id, src_run_dct["info"]["user_id"])
             path = os.path.join(input_dir, "artifacts")
             if os.path.exists(_filesystem.mk_local_path(path)):
                 self.mlflow_client.log_artifacts(run_id, mk_local_path(path))
@@ -99,18 +98,6 @@ class RunImporter():
                 with open(output_path, "w") as f:
                     yaml.dump(mlmodel, f)
                 self.mlflow_client.log_artifact(run_id, output_path,  f"{model_path}")
-
-    def _import_run_data(self, run_dct, run_id, src_user_id):
-        run_data_importer.log_params(self.mlflow_client, run_dct, run_id, MAX_PARAMS_TAGS_PER_BATCH)
-        run_data_importer.log_metrics(self.mlflow_client, run_dct, run_id, MAX_METRICS_PER_BATCH)
-        run_data_importer.log_tags(
-            self.mlflow_client, 
-            run_dct, 
-            run_id, 
-            MAX_PARAMS_TAGS_PER_BATCH, 
-            self.in_databricks, 
-            src_user_id, 
-            self.use_src_user_id)
 
     def _upload_databricks_notebook(self, input_dir, src_run_dct, dst_notebook_dir):
         run_id = src_run_dct["info"]["run_id"]


### PR DESCRIPTION
# 変更点
- 簡単な README の記述: 791fe8f
- run の生成を行わないようにする: 37584f5
  - import 時に run の生成を行わず、対象の run_id を取得、その run_id から mlflow.entities.Run を取得するように変更した
- 余計な log_* や experiment の作成をしないようにする: e295993